### PR TITLE
use daemon property instead

### DIFF
--- a/SnifferAPI/UART.py
+++ b/SnifferAPI/UART.py
@@ -217,6 +217,7 @@ def list_serial_ports():
     # Scan for available ports.
     return list_ports.comports()
 
+
 if __name__ == "__main__":
     import time
     t_start = time.time()

--- a/SnifferAPI/UART.py
+++ b/SnifferAPI/UART.py
@@ -217,7 +217,6 @@ def list_serial_ports():
     # Scan for available ports.
     return list_ports.comports()
 
-
 if __name__ == "__main__":
     import time
     t_start = time.time()

--- a/SnifferAPI/UART.py
+++ b/SnifferAPI/UART.py
@@ -140,7 +140,7 @@ class Uart:
 
         self.worker_thread = Thread(target=self._read_worker)
         self.reading = True
-        self.worker_thread.setDaemon(True)
+        self.worker_thread.daemon = True
         self.worker_thread.start()
 
     def _read_worker(self):


### PR DESCRIPTION
silent deprecate warning:
```python
/usr/local/lib/python3.10/site-packages/SnifferAPI/UART.py:143: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
[2428](https://github.com/jouzen/pyring/actions/runs/3250136578/jobs/5333400323#step:5:2565)
    self.worker_thread.setDaemon(True)
```
ref: https://github.com/python/cpython/pull/25174