### PR TITLE
setup: relax python version requirements to let user decide upper limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'nrf-sniffer-cli = SnifferAPI.cli:main'
         ]
     },
-    python_requires='>=3.7, <=3.11',
+    python_requires='>=3.7',
     install_requires=[
         'pyserial>=3.4',
         'psutil'


### PR DESCRIPTION
The python 3.12 has been out for a year. Let's just remove the forced Python version upper limit and let the user to decide what version to use.